### PR TITLE
Update server image to 44b06dd-2274446764

### DIFF
--- a/clusters/local.home/overlays/prod/kustomization.yaml
+++ b/clusters/local.home/overlays/prod/kustomization.yaml
@@ -7,6 +7,6 @@ images:
   newTag: b8a2b2a-2774814127
 - name: quay.io/gnunn/server
   newName: quay.io/gnunn/server
-  newTag: 484a3b3-3379844410
+  newTag: 44b06dd-2274446764
 resources:
 - ../../../../environments/overlays/prod


### PR DESCRIPTION
## Security Checklist

- [ ] [Quay Image Vulnerabilities](https://quay.io/gnunn/server:44b06dd-2274446764)
- [ ] [Advanced Cluster Security Image Vulnerabilities and Policies](https://central-stackrox.apps.home.ocplab.com:443/main/vulnerability-management/images/sha256:bd1475eb90e86899ed5fd7a25e3a14d474826ddd4665828258eb5d6a012b9391)
- [ ] [Sonarqube Results](https://sonarqube-dev-tools.apps.home.ocplab.com/dashboard?id=product-catalog-server)

## Code Changes
- [484a3b3 to 44b06dd](https://github.com/gnunn-gitops/product-catalog-server/compare/484a3b3..44b06dd