### PR TITLE
Update server image to f6a5e87-2960118757

### DIFF
--- a/clusters/local.home/overlays/prod/kustomization.yaml
+++ b/clusters/local.home/overlays/prod/kustomization.yaml
@@ -7,6 +7,6 @@ images:
   newTag: b8a2b2a-2774814127
 - name: quay.io/gnunn/server
   newName: quay.io/gnunn/server
-  newTag: 44b06dd-2274446764
+  newTag: f6a5e87-2960118757
 resources:
 - ../../../../environments/overlays/prod


### PR DESCRIPTION
## Security Checklist

- [x] [Quay Image Vulnerabilities](https://quay.io/gnunn/server:f6a5e87-2960118757)
- [x] [Advanced Cluster Security Image Vulnerabilities and Policies](https://central-stackrox.apps.home.ocplab.com:443/main/vulnerability-management/images/sha256:f117ba0156f47bf33d4db5446a03f2e117e90f800d11e6bc8e2a0c2c467f247d)
- [x] [Sonarqube Results](https://sonarqube-dev-tools.apps.home.ocplab.com/dashboard?id=product-catalog-server)

## Code Changes
- [44b06dd to f6a5e87](https://github.com/gnunn-gitops/product-catalog-server/compare/44b06dd..f6a5e87)