### PR TITLE
Update server image to d54ff71-2118238063

### DIFF
--- a/clusters/local.home/overlays/prod/kustomization.yaml
+++ b/clusters/local.home/overlays/prod/kustomization.yaml
@@ -7,6 +7,6 @@ images:
   newTag: b8a2b2a-2774814127
 - name: quay.io/gnunn/server
   newName: quay.io/gnunn/server
-  newTag: 1b82381-564090973
+  newTag: d54ff71-2118238063
 resources:
 - ../../../../environments/overlays/prod


### PR DESCRIPTION
## Security Checklist

- [ ] [Quay Image Vulnerabilities](https://quay.io/gnunn/server:d54ff71-2118238063)
- [ ] [Advanced Cluster Security Image Vulnerabilities and Policies](https://central.stackrox.svc:443/main/vulnerability-management/images/sha256:897ffc9d7f2932c17600e9a453dd28d5345aeff84c2fed8f27098d2caec30f0d)
- [ ] [Sonarqube Results](https://sonarqube-dev-tools.apps.home.ocplab.com/dashboard?id=product-catalog-server)

## Code Changes
- [ ] [ to d54ff71](https://github.com/gnunn-gitops/product-catalog-server/compare/..d54ff71)