### PR TITLE
Update server image to e962a39-1812724838

### DIFF
--- a/clusters/local.home/overlays/prod/kustomization.yaml
+++ b/clusters/local.home/overlays/prod/kustomization.yaml
@@ -7,6 +7,6 @@ images:
   newTag: b8a2b2a-2774814127
 - name: quay.io/gnunn/server
   newName: quay.io/gnunn/server
-  newTag: 1b82381-564090973
+  newTag: e962a39-1812724838
 resources:
 - ../../../../environments/overlays/prod


### PR DESCRIPTION
## Security Checklist

- [x] [Quay Image Vulnerabilities](https://quay.io/gnunn/server:e962a39-1812724838)
- [x] [Advanced Cluster Security Image Vulnerabilities and Policies](https://central.stackrox.svc:443/main/vulnerability-management/images/sha256:063c79a77a4444ad9a6c5ceb6ca3482e47848953dcb83cca0579fe4d47b30c36)
- [x] [Sonarqube Results](https://sonarqube-dev-tools.apps.home.ocplab.com/dashboard?id=product-catalog-server)

## Code Changes
- [x] [ to e962a39](https://github.com/gnunn-gitops/product-catalog-server/compare/..e962a39)