### PR TITLE
Update server image to 81f2725-3009956294

### DIFF
--- a/clusters/local.home/overlays/prod/kustomization.yaml
+++ b/clusters/local.home/overlays/prod/kustomization.yaml
@@ -7,6 +7,6 @@ images:
   newTag: b8a2b2a-2774814127
 - name: quay.io/gnunn/server
   newName: quay.io/gnunn/server
-  newTag: e962a39-1812724838
+  newTag: 81f2725-3009956294
 resources:
 - ../../../../environments/overlays/prod


### PR DESCRIPTION
## Security Checklist

- [x] [Quay Image Vulnerabilities](https://quay.io/gnunn/server:81f2725-3009956294)
- [x] [Advanced Cluster Security Image Vulnerabilities and Policies](https://central-stackrox.apps.home.ocplab.com:443/main/vulnerability-management/images/sha256:825ff6f346ffcf8f011a6cdce8de30dd86bc8f927a85ae0e4df8ddc73ce795e0)
- [x] [Sonarqube Results](https://sonarqube-dev-tools.apps.home.ocplab.com/dashboard?id=product-catalog-server)

## Code Changes
- [x] [ to 81f2725](https://github.com/gnunn-gitops/product-catalog-server/compare/..81f2725)