### PR TITLE
Update server image to 5941438-1062242612

### DIFF
--- a/clusters/local.home/overlays/prod/kustomization.yaml
+++ b/clusters/local.home/overlays/prod/kustomization.yaml
@@ -7,6 +7,6 @@ images:
   newTag: b8a2b2a-2774814127
 - name: quay.io/gnunn/server
   newName: quay.io/gnunn/server
-  newTag: 81f2725-3009956294
+  newTag: 5941438-1062242612
 resources:
 - ../../../../environments/overlays/prod


### PR DESCRIPTION
## Security Checklist

- [x] [Quay Image Vulnerabilities](https://quay.io/gnunn/server:5941438-1062242612)
- [x] [Advanced Cluster Security Image Vulnerabilities and Policies](https://central-stackrox.apps.home.ocplab.com:443/main/vulnerability-management/images/sha256:654e00b59b691e0d11b90873f34eec5cc88bcc23ffd75fcc9fae37792c9e2e50)
- [x] [Sonarqube Results](https://sonarqube-dev-tools.apps.home.ocplab.com/dashboard?id=product-catalog-server)

## Code Changes
- [x] [81f2725 to 5941438](https://github.com/gnunn-gitops/product-catalog-server/compare/81f2725..5941438)