### PR TITLE
Update server image to ec8e7db-2174267558

### DIFF
--- a/clusters/local.home/overlays/prod/kustomization.yaml
+++ b/clusters/local.home/overlays/prod/kustomization.yaml
@@ -7,6 +7,6 @@ images:
   newTag: b8a2b2a-2774814127
 - name: quay.io/gnunn/server
   newName: quay.io/gnunn/server
-  newTag: 7c66059-3437573871
+  newTag: ec8e7db-2174267558
 resources:
 - ../../../../environments/overlays/prod


### PR DESCRIPTION
## Security Checklist

- [ ] [Quay Image Vulnerabilities](https://quay.io/gnunn/server:ec8e7db-2174267558)
- [ ] [Advanced Cluster Security Image Vulnerabilities and Policies](https://central-stackrox.apps.home.ocplab.com:443/main/vulnerability-management/images/sha256:01377e3688ff93b75829e0d53b898279733c3fec86f5ae6d606f52c1c27eadaf)
- [ ] [Sonarqube Results](https://sonarqube-dev-tools.apps.home.ocplab.com/dashboard?id=product-catalog-server)

## Code Changes
- [ ] [7c66059 to ec8e7db](https://github.com/gnunn-gitops/product-catalog-server/compare/7c66059..ec8e7db)