### PR TITLE
Update server image to 9628e66-2031938014

### DIFF
--- a/clusters/local.home/overlays/prod/kustomization.yaml
+++ b/clusters/local.home/overlays/prod/kustomization.yaml
@@ -7,6 +7,6 @@ images:
   newTag: b8a2b2a-2774814127
 - name: quay.io/gnunn/server
   newName: quay.io/gnunn/server
-  newTag: 7c66059-3437573871
+  newTag: 9628e66-2031938014
 resources:
 - ../../../../environments/overlays/prod


### PR DESCRIPTION
## Security Checklist

- [x] [Quay Image Vulnerabilities](https://quay.io/gnunn/server:9628e66-2031938014)
- [x] [Advanced Cluster Security Image Vulnerabilities and Policies](https://central-stackrox.apps.home.ocplab.com:443/main/vulnerability-management/images/sha256:94a908a789eed62c4fadfa98b31baa77d8b770507cc0521200edb63771fad967)
- [x] [Sonarqube Results](https://sonarqube-dev-tools.apps.home.ocplab.com/dashboard?id=product-catalog-server)

## Code Changes
- [x] [7c66059 to 9628e66](https://github.com/gnunn-gitops/product-catalog-server/compare/7c66059..9628e66)