### PR TITLE
Update server image to 8f03a61-150610122

### DIFF
--- a/clusters/local.home/overlays/prod/kustomization.yaml
+++ b/clusters/local.home/overlays/prod/kustomization.yaml
@@ -7,6 +7,6 @@ images:
   newTag: b8a2b2a-2774814127
 - name: quay.io/gnunn/server
   newName: quay.io/gnunn/server
-  newTag: 9628e66-2031938014
+  newTag: 8f03a61-150610122
 resources:
 - ../../../../environments/overlays/prod


### PR DESCRIPTION
## Security Checklist

- [x] [Quay Image Vulnerabilities](https://quay.io/gnunn/server:8f03a61-150610122)
- [x] [Advanced Cluster Security Image Vulnerabilities and Policies](https://central-stackrox.apps.home.ocplab.com:443/main/vulnerability-management/images/sha256:db7665cbcd5bd7b29c42d83fe4013446360051173354aa8c1783bff50df970ce)
- [x] [Sonarqube Results](https://sonarqube-dev-tools.apps.home.ocplab.com/dashboard?id=product-catalog-server)

## Code Changes
- [x] [9628e66 to 8f03a61](https://github.com/gnunn-gitops/product-catalog-server/compare/9628e66..8f03a61)