### PR TITLE
Update server image to ab9effd-1527969016

### DIFF
--- a/clusters/local.home/overlays/prod/kustomization.yaml
+++ b/clusters/local.home/overlays/prod/kustomization.yaml
@@ -7,6 +7,6 @@ images:
   newTag: b8a2b2a-2774814127
 - name: quay.io/gnunn/server
   newName: quay.io/gnunn/server
-  newTag: 8f03a61-150610122
+  newTag: ab9effd-1527969016
 resources:
 - ../../../../environments/overlays/prod


### PR DESCRIPTION
## Security Checklist

- [x] [Quay Image Vulnerabilities](https://quay.io/gnunn/server:ab9effd-1527969016)
- [x] [Advanced Cluster Security Image Vulnerabilities and Policies](https://central-stackrox.apps.home.ocplab.com:443/main/vulnerability-management/images/sha256:fd48c001b66a9660d3e95590902d1aca15fb4103c67afd46c03e8a0d08dc12a1)
- [x] [Sonarqube Results](https://sonarqube-dev-tools.apps.home.ocplab.com/dashboard?id=product-catalog-server)

## Code Changes
- [x] [8f03a61 to ab9effd](https://github.com/gnunn-gitops/product-catalog-server/compare/8f03a61..ab9effd)