### PR TITLE
Update server image to 915cb4b-2543585191

### DIFF
--- a/clusters/local.home/overlays/prod/kustomization.yaml
+++ b/clusters/local.home/overlays/prod/kustomization.yaml
@@ -7,6 +7,6 @@ images:
   newTag: b8a2b2a-2774814127
 - name: quay.io/gnunn/server
   newName: quay.io/gnunn/server
-  newTag: f542710-3898488790
+  newTag: 915cb4b-2543585191
 resources:
 - ../../../../environments/overlays/prod


### PR DESCRIPTION
## Security Checklist

- [x] [Quay Image Vulnerabilities](https://quay.io/gnunn/server:915cb4b-2543585191)
- [x] [Advanced Cluster Security Image Vulnerabilities and Policies](https://central-stackrox.apps.home.ocplab.com:443/main/vulnerability-management/images/sha256:8af83b857c63312e515208af7cf09ec9198b49e656246719e6adb17bdcd44e16)
- [x] [Sonarqube Results](https://sonarqube-dev-tools.apps.home.ocplab.com/dashboard?id=product-catalog-server)

## Code Changes
- [x] [f542710 to 915cb4b](https://github.com/gnunn-gitops/product-catalog-server/compare/f542710..915cb4b)