### PR TITLE
Update server image to fa7de4d-586590414

### DIFF
--- a/clusters/local.home/overlays/prod/kustomization.yaml
+++ b/clusters/local.home/overlays/prod/kustomization.yaml
@@ -7,6 +7,6 @@ images:
   newTag: b8a2b2a-2774814127
 - name: quay.io/gnunn/server
   newName: quay.io/gnunn/server
-  newTag: 915cb4b-2543585191
+  newTag: fa7de4d-586590414
 resources:
 - ../../../../environments/overlays/prod


### PR DESCRIPTION
## Security Checklist

- [x] [Quay Image Vulnerabilities](https://quay.io/gnunn/server:fa7de4d-586590414)
- [x] [Advanced Cluster Security Image Vulnerabilities and Policies](https://central-stackrox.apps.home.ocplab.com:443/main/vulnerability-management/images/sha256:edabd98516cf0c488fa923635f2c1612e47260b1e6cde591de88abbc6d25a3b1)
- [x] [Sonarqube Results](https://sonarqube-dev-tools.apps.home.ocplab.com/dashboard?id=product-catalog-server)

## Code Changes
- [x] [915cb4b to fa7de4d](https://github.com/gnunn-gitops/product-catalog-server/compare/915cb4b..fa7de4d)