### PR TITLE
Update server image to 2db54d6-414827132

### DIFF
--- a/clusters/local.home/overlays/prod/kustomization.yaml
+++ b/clusters/local.home/overlays/prod/kustomization.yaml
@@ -7,6 +7,6 @@ images:
   newTag: b8a2b2a-2774814127
 - name: quay.io/gnunn/server
   newName: quay.io/gnunn/server
-  newTag: fa7de4d-586590414
+  newTag: 2db54d6-414827132
 resources:
 - ../../../../environments/overlays/prod


### PR DESCRIPTION
## Security Checklist

- [x] [Quay Image Vulnerabilities](https://quay.io/gnunn/server:2db54d6-414827132)
- [x] [Advanced Cluster Security Image Vulnerabilities and Policies](https://central-stackrox.apps.home.ocplab.com:443/main/vulnerability-management/images/sha256:74b2be0826ca5a23df0a50343e96cf3d4065b12df9a79c305b62ed3cea9d0af4)
- [x] [Sonarqube Results](https://sonarqube-dev-tools.apps.home.ocplab.com/dashboard?id=product-catalog-server)

## Code Changes
- [x] [fa7de4d to 2db54d6](https://github.com/gnunn-gitops/product-catalog-server/compare/fa7de4d..2db54d6)