### PR TITLE
Update server image to 82da37a-2VzqJTObGIIV9bQRPm6Tr1ye4gx

### DIFF
--- a/clusters/local.home/overlays/prod/kustomization.yaml
+++ b/clusters/local.home/overlays/prod/kustomization.yaml
@@ -7,6 +7,6 @@ images:
   newTag: b8a2b2a-2774814127
 - name: quay.io/gnunn/server
   newName: quay.io/gnunn/server
-  newTag: 64801b3-2VwE8BU34ywuyzAiry9l6gfhvfw
+  newTag: 82da37a-2VzqJTObGIIV9bQRPm6Tr1ye4gx
 resources:
 - ../../../../environments/overlays/prod


### PR DESCRIPTION
## Security Checklist

- [x] [Quay Image Vulnerabilities](https://quay.io/gnunn/server:82da37a-2VzqJTObGIIV9bQRPm6Tr1ye4gx)
- [x] [Advanced Cluster Security Image Vulnerabilities and Policies](https://central-stackrox.apps.hub.ocplab.com:443/main/vulnerability-management/images/sha256:a1a83b657b9e9751de0e8c4b979830958d1cf5f58d840e5f5717b3fb403188cf)
- [x] [Sonarqube Results](https://sonarqube-dev-tools.apps.hub.ocplab.com/dashboard?id=product-catalog-server)

## Code Changes
- [x] [64801b3 to 82da37a](https://github.com/gnunn-gitops/product-catalog-server/compare/64801b3..82da37a)