### PR TITLE
Update server image to 881c089-2W1zbC2XeLB0LEq9n71Cq4dIdXl

### DIFF
--- a/clusters/local.home/overlays/prod/kustomization.yaml
+++ b/clusters/local.home/overlays/prod/kustomization.yaml
@@ -7,6 +7,6 @@ images:
   newTag: b8a2b2a-2774814127
 - name: quay.io/gnunn/server
   newName: quay.io/gnunn/server
-  newTag: 78a2ec3-2W1lr0MyJuMNbYmukoOOgqv98Zh
+  newTag: 881c089-2W1zbC2XeLB0LEq9n71Cq4dIdXl
 resources:
 - ../../../../environments/overlays/prod


### PR DESCRIPTION
## Security Checklist

- [x] [Quay Image Vulnerabilities](https://quay.io/gnunn/server:881c089-2W1zbC2XeLB0LEq9n71Cq4dIdXl)
- [x] [Advanced Cluster Security Image Vulnerabilities and Policies](https://central-stackrox.apps.hub.ocplab.com:443/main/vulnerability-management/images/sha256:a74ac69013f318b605261d3333ac591d3fb615d9fadc77caa8bd4a648678cb13)
- [x] [Sonarqube Results](https://sonarqube-dev-tools.apps.hub.ocplab.com/dashboard?id=product-catalog-server)

## Code Changes
- [x] [78a2ec3 to 881c089](https://github.com/gnunn-gitops/product-catalog-server/compare/78a2ec3..881c089)