### PR TITLE
Update server image to 78de3b2-2WZwa8QY6oNfg0jh5NTBnuKHmEO

### DIFF
--- a/clusters/local.home/overlays/prod/kustomization.yaml
+++ b/clusters/local.home/overlays/prod/kustomization.yaml
@@ -7,6 +7,6 @@ images:
   newTag: b8a2b2a-2774814127
 - name: quay.io/gnunn/server
   newName: quay.io/gnunn/server
-  newTag: 1c02b97-2WIsrZ3TLzSVmYzuvvMlugo54nW
+  newTag: 78de3b2-2WZwa8QY6oNfg0jh5NTBnuKHmEO
 resources:
 - ../../../../environments/overlays/prod


### PR DESCRIPTION
## Security Checklist

- [x] [Quay Image Vulnerabilities](https://quay.io/gnunn/server:78de3b2-2WZwa8QY6oNfg0jh5NTBnuKHmEO)
- [x] [Advanced Cluster Security Image Vulnerabilities and Policies](https://central-stackrox.apps.hub.ocplab.com:443/main/vulnerability-management/images/sha256:14d989cc91355e98ce3cb99fb3e9f997ba3051096782bd0f73b60f1cf65c5f44)
- [x] [Sonarqube Results](https://sonarqube-dev-tools.apps.hub.ocplab.com/dashboard?id=product-catalog-server)

## Code Changes
- [x] [1c02b97 to 78de3b2](https://github.com/gnunn-gitops/product-catalog-server/compare/1c02b97..78de3b2)